### PR TITLE
Make variable names in deploy script match those in `cw-dao-dapp` env.local

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Then, deploy the contract to a local chain with:
 bash scripts/deploy_local.sh wasm1aq69sg9sdrqgflvrdnnjvaxmeu6azx2hyugk84
 ```
 
-> Note: This Wasm account is from the [default account](default-account.txt), which you can use for testing. You can pass in any wasm account you want to use.
+> Note: This Wasm account is from the [default account](default-account.txt), which you can use for testing. You can pass in any wasm account you want to use, but *please not one where you store real funds*. (:
 
 This will run a chain locally in a docker container, then build and deploy the contracts to that chain.
 

--- a/README.md
+++ b/README.md
@@ -51,8 +51,10 @@ First, run the front end, which will pass the chain info to Keplr. From there, g
 Then, deploy the contract to a local chain with:
 
 ``` sh
-bash scripts/deploy_local.sh [your-wasm-address]
+bash scripts/deploy_local.sh wasm1aq69sg9sdrqgflvrdnnjvaxmeu6azx2hyugk84
 ```
+
+> Note: This Wasm account is from the [default account](default-account.txt), which you can use for testing. You can pass in any wasm account you want to use.
 
 This will run a chain locally in a docker container, then build and deploy the contracts to that chain.
 

--- a/scripts/deploy_local.sh
+++ b/scripts/deploy_local.sh
@@ -103,5 +103,5 @@ CW_DAO_CONTRACT=$($BINARY q wasm list-contract-by-code $CW_DAO_CODE --output jso
 printf "\n ------------------------ \n"
 printf "Config Variables \n\n"
 
-echo "CW20 Contract: $CW20_CONTRACT"
-echo "CW_DAO Contract: $CW_DAO_CONTRACT"
+echo "NEXT_PUBLIC_DAO_TOKEN_ADDRESS: $CW20_CONTRACT"
+echo "NEXT_PUBLIC_DAO_CONTRACT_ADDRESS: $CW_DAO_CONTRACT"

--- a/scripts/deploy_local.sh
+++ b/scripts/deploy_local.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ "$1" = "" ]
 then


### PR DESCRIPTION
Removes ambiguity about which address to place in which .env.local field. 

(This issue is related to #50)